### PR TITLE
feat: compile only the redis-cli

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -16,7 +16,7 @@ download_release "$ASDF_INSTALL_VERSION" "$release_file"
 tar xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
 
 cd "$ASDF_DOWNLOAD_PATH"
-make BUILD_TLS=yes
+make BUILD_TLS=yes redis-cli
 
 # Remove the tar.gz file since we don't need to keep it
 rm "$release_file"


### PR DESCRIPTION
Compiles only the redis-cli, saving build-time.

On my system, it compiles in approximately 24% less time.

See: https://github.com/redis/redis/blob/unstable/src/Makefile#L463